### PR TITLE
fix bug of as.treedata for eclust

### DIFF
--- a/R/as-treedata.R
+++ b/R/as-treedata.R
@@ -25,10 +25,14 @@ as.treedata.eclust2 <- function(
     .data,
     bycol = TRUE,
     assay = 1,
-    longer = FALSE,
+    longer = TRUE,
     metadata = TRUE) {
-
-    da <- assay(.data, assay) |> data.frame() |> rownames_to_column(var = "label")
+    
+    da <- assay(.data, assay) 
+    if (bycol){
+       da <- t(da)
+    }
+    da <- da |> data.frame() |> rownames_to_column(var = 'label')
 
     if (is.null(assayNames(.data)[assay])) {
         name <- 'counts'
@@ -39,11 +43,11 @@ as.treedata.eclust2 <- function(
     if (bycol) {
         ph <- colhclust(.data) |> as.phylo()
         md <- colData(.data)
-        names_to <- "sample"
+        names_to <- "feature"
     } else {
         ph <- rowhclust(.data) |> as.phylo()
         md <- rowData(.data)
-        names_to <- 'feature'
+        names_to <- 'sample'
     }
 
     if (longer) {
@@ -56,11 +60,11 @@ as.treedata.eclust2 <- function(
                                     tidyselect::all_of(name)))
     }
 
-    treedata <- treedata(phylo = ph) |> left_join(da)
+    treedata <- treedata(phylo = ph) |> left_join(da, by='label')
 
     if (metadata) {
         md <- data.frame(md) |> rownames_to_column(var = "label")
-        treedata <- left_join(treedata, md)
+        treedata <- left_join(treedata, md, by='label')
     }
 
     return(treedata)

--- a/example.r
+++ b/example.r
@@ -3,8 +3,9 @@ data(airway, package="airway")
 
 library(eclust)
 ee <- eclust(airway)
-tree <- as.treedata(ee)
 
-library(ggtree)
-ggtree(tree) + geom_tiplab(aes(color=dex)) + hexpand(.2)
+tree1 <- as.treedata(ee, longer = FALSE)
+tree2 <- as.treedata(ee, longer = TRUE)
+
+ggtree(tree1) + geom_tiplab(aes(color=dex)) + hexpand(.2)
 


### PR DESCRIPTION
fix bug of `as.treedata` for `eclust`

```
> library(SummarizedExperiment)
> data(airway, package="airway")
> library(ggtree)
> library(eclust)
> ee <- eclust(airway)
>
> tree1 <- as.treedata(ee, longer = FALSE)
> tree2 <- as.treedata(ee, longer = TRUE)
> tree2
'treedata' S4 object'.

...@ phylo:

Phylogenetic tree with 8 tips and 7 internal nodes.

Tip labels:
  SRR1039508, SRR1039509, SRR1039512, SRR1039513, SRR1039516, SRR1039517, ...

Rooted; includes branch lengths.

with the following features available:
  '', 'counts', 'SampleName', 'cell', 'dex', 'albut', 'Run', 'avgLength',
'Experiment', 'Sample', 'BioSample'.

# The associated data tibble abstraction: 15 × 13
# The 'node', 'label' and 'isTip' are from the phylo tree.
    node label      isTip counts   SampleName cell   dex   albut Run   avgLength
   <int> <chr>      <lgl> <list>   <fct>      <fct>  <fct> <fct> <fct>     <int>
 1     1 SRR1039508 TRUE  <tibble> GSM1275862 N61311 untrt untrt SRR1…       126
 2     2 SRR1039509 TRUE  <tibble> GSM1275863 N61311 trt   untrt SRR1…       126
 3     3 SRR1039512 TRUE  <tibble> GSM1275866 N0526… untrt untrt SRR1…       126
 4     4 SRR1039513 TRUE  <tibble> GSM1275867 N0526… trt   untrt SRR1…        87
 5     5 SRR1039516 TRUE  <tibble> GSM1275870 N0806… untrt untrt SRR1…       120
 6     6 SRR1039517 TRUE  <tibble> GSM1275871 N0806… trt   untrt SRR1…       126
 7     7 SRR1039520 TRUE  <tibble> GSM1275874 N0610… untrt untrt SRR1…       101
 8     8 SRR1039521 TRUE  <tibble> GSM1275875 N0610… trt   untrt SRR1…        98
 9     9 NA         FALSE <NULL>   NA         NA     NA    NA    NA           NA
10    10 NA         FALSE <NULL>   NA         NA     NA    NA    NA           NA
# ℹ 5 more rows
# ℹ 3 more variables: Experiment <fct>, Sample <fct>, BioSample <fct>
# ℹ Use `print(n = ...)` to see more rows
> ggtree(tree1) + geom_tiplab(aes(color=dex)) + hexpand(.2)
```
![捕获](https://github.com/YuLab-SMU/eclust/assets/17870644/d7b84ad9-6aed-49f4-af41-ec002156b09a)

